### PR TITLE
dirty-equals 0.10.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ requirements:
 # Assert fails
 # assert 946684800.123 == IsDatetime(approx=datetime.datetime(2000, 1, 1, 0, 0), unix_number=True)
 {% set tests_to_deselect = " --deselect=tests/test_datetime.py::test_is_datetime" %}
+# AssertionError: assert <tests.test_inspection.Foo object at 0x00000166005F7F10> == HasRepr(IsStr(regex='<tests.test_inspection.Foo object at 0x[0-9a-f]{6,20}>'))
+{% set tests_to_deselect = " --deselect=tests/test_inspection.py::test_has_repr" %}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,33 +10,50 @@ source:
   sha256: 623d7a07c5ba437f1a834c6246d1e3eb97238ca70331c61a499d9aabd757b899
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
-  noarch: python
+  skip: true  # [py<39]
 
 requirements:
   host:
+    - python
     - pip
     - hatchling
-    - python {{ python_min }}
   run:
-    - python >={{ python_min }}
+    - python
+  run_constrained:
+    - pydantic >=2.4.2
+
+# E   ModuleNotFoundError: No module named 'pytest_examples'
+{% set ignore_tests = " --ignore=tests/test_docs.py" %}
+# Assert fails
+# assert 946684800.123 == IsDatetime(approx=datetime.datetime(2000, 1, 1, 0, 0), unix_number=True)
+{% set tests_to_deselect = " --deselect=tests/test_datetime.py::test_is_datetime" %}
 
 test:
+  source_files:
+    - tests
   imports:
     - dirty_equals
-  commands:
-    - pip check
   requires:
     - pip
-    - python {{ python_min }}
+    - pytest
+    - pydantic >=2.4.2
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests {{ ignore_tests }} {{ tests_to_deselect }}
 
 about:
   home: https://dirty-equals.helpmanual.io
   summary: Doing dirty (but extremely useful) things with equals.
+  description: dirty-equals is a python library that (mis)uses the __eq__ method to 
+    make python code (generally unit tests) more declarative and therefore easier to read and write.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   dev_url: https://github.com/samuelcolvin/dirty-equals
+  doc_url: https://dirty-equals.helpmanual.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
dirty-equals 0.10.0 

**Destination channel:** Defaults

### Links

- [PKG-9860]
- dev_url:        https://github.com/samuelcolvin/dirty-equals/tree/v0.10.0
- conda_forge:    https://github.com/conda-forge/dirty-equals-feedstock
- pypi:           https://pypi.org/project/dirty-equals/0.10.0
- pypi inspector: https://inspector.pypi.io/project/dirty-equals/0.10.0

### Explanation of changes:

- new version number


[PKG-9860]: https://anaconda.atlassian.net/browse/PKG-9860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ