### PR TITLE
dirty-equals 0.10.0: Rebuild for py314

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  number: 0
+  number: 1
   skip: true  # [py<39]
 
 requirements:
@@ -40,7 +40,7 @@ test:
   requires:
     - pip
     - pytest
-    - pydantic >=2.4.2
+    - pydantic >=2.4.2  # [not py==314]
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v tests {{ ignore_tests }} {{ tests_to_deselect }}
+    - pytest -v tests {{ ignore_tests }} {{ tests_to_deselect }}  # [not py==314]
 
 about:
   home: https://dirty-equals.helpmanual.io


### PR DESCRIPTION
- Disable pydantic in tests for py314 as it's a circular dependency of pydantic-core.